### PR TITLE
[FEAT] Support of custom license file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module license-generator
 
 go 1.19
+
+require github.com/BurntSushi/toml v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
+github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"embed"
 	"license-generator/src/args"
+	"license-generator/src/config"
 	"license-generator/src/utils"
 	"os"
 	"strings"
@@ -17,6 +18,18 @@ func main() {
 	arg := args.ParseCliArgs()
 	if arg.Info {
 		os.Exit(0)
+	}
+	// import custom licenses if needed
+	if arg.ConfigPath != "" {
+		licenses, err := config.GetLicenseConfigs(arg.ConfigPath)
+		utils.HandleError(err)
+		contextPath, err := os.Getwd()
+		utils.HandleError(err)
+		println(contextPath)
+		for _, license := range licenses {
+			println("Path in main.go:", license.Path)
+		}
+		config.AddLicensesToMap(licenses, contextPath)
 	}
 	arg.HandleArgs()
 

--- a/main.go
+++ b/main.go
@@ -25,11 +25,9 @@ func main() {
 		utils.HandleError(err)
 		contextPath, err := os.Getwd()
 		utils.HandleError(err)
-		println(contextPath)
-		for _, license := range licenses {
-			println("Path in main.go:", license.Path)
-		}
+		contextPath += "/" + arg.ConfigPath
 		config.AddLicensesToMap(licenses, contextPath)
+		println("")
 	}
 	arg.HandleArgs()
 
@@ -46,7 +44,9 @@ func findLicense(license args.License) string {
 		utils.HandleError(err)
 		return string(content)
 	}
-	return ""
+	b, err := os.ReadFile(license.File)
+	utils.HandleError(err)
+	return string(b)
 }
 
 func parseLicense(arg *args.Arguments, license string) string {

--- a/main.go
+++ b/main.go
@@ -28,9 +28,12 @@ func main() {
 }
 
 func findLicense(license args.License) string {
-	content, err := staticContent.ReadFile("resources/template/license/" + string(license))
-	utils.HandleError(err)
-	return string(content)
+	if license.File == "~" {
+		content, err := staticContent.ReadFile("resources/template/license/" + license.Name)
+		utils.HandleError(err)
+		return string(content)
+	}
+	return ""
 }
 
 func parseLicense(arg *args.Arguments, license string) string {

--- a/main.go
+++ b/main.go
@@ -23,10 +23,11 @@ func main() {
 	if arg.ConfigPath != "" {
 		licenses, err := config.GetLicenseConfigs(arg.ConfigPath)
 		utils.HandleError(err)
-		contextPath, err := os.Getwd()
+		// set the global context path
+		utils.ContextPath, err = os.Getwd()
 		utils.HandleError(err)
-		contextPath += "/" + arg.ConfigPath
-		config.AddLicensesToMap(licenses, contextPath)
+		utils.ContextPath += "/"
+		config.AddLicensesToMap(licenses, arg.ConfigPath)
 		println("")
 	}
 	arg.HandleArgs()

--- a/resources/example/config/cc0.license
+++ b/resources/example/config/cc0.license
@@ -1,0 +1,36 @@
+
+Creative Commons Legal Code
+CC0 1.0 Universal
+Official translations of this legal tool are available
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer exclusive Copyright and Related Rights (defined below) upon the creator and subsequent owner(s) (each and all, an "owner") of an original work of authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the purpose of contributing to a commons of creative, cultural and scientific works ("Commons") that the public can reliably and without fear of later claims of infringement build upon, modify, incorporate in other works, reuse and redistribute as freely as possible in any form whatsoever and for any purposes, including without limitation commercial purposes. These owners may contribute to the Commons to promote the ideal of a free culture and the further production of creative, cultural and scientific works, or to gain reputation or greater distribution for their Work in part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation of additional consideration or compensation, the person associating CC0 with a Work (the "Affirmer"), to the extent that he or she is an owner of Copyright and Related Rights in the Work, voluntarily elects to apply CC0 to the Work and publicly distribute the Work under its terms, with knowledge of his or her Copyright and Related Rights in the Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be protected by copyright and related or neighboring rights ("Copyright and Related Rights"). Copyright and Related Rights include, but are not limited to, the following:
+
+   i.   the right to reproduce, adapt, distribute, perform, display, communicate, and translate a Work;
+   ii.  moral rights retained by the original author(s) and/or performer(s);
+   iii. publicity and privacy rights pertaining to a person's image or likeness depicted in a Work;
+   iv.  rights protecting against unfair competition in regards to a Work, subject to the limitations in paragraph 4(a), below;
+   v.   rights protecting the extraction, dissemination, use and reuse of data in a Work;
+   vi.  database rights (such as those arising under Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, and under any national implementation thereof, including any amended or successor version of such directive); and
+   vii. other similar, equivalent or corresponding rights throughout the world based on applicable law or treaty, and any national implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention of, applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and unconditionally waives, abandons, and surrenders all of Affirmer's Copyright and Related Rights and associated claims and causes of action, whether now known or unknown (including existing as well as future claims and causes of action), in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each member of the public at large and to the detriment of Affirmer's heirs and successors, fully intending that such Waiver shall not be subject to revocation, rescission, cancellation, termination, or any other legal or equitable action to disrupt the quiet enjoyment of the Work by the public as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason be judged legally invalid or ineffective under applicable law, then the Waiver shall be preserved to the maximum extent permitted taking into account Affirmer's express Statement of Purpose. In addition, to the extent the Waiver is so judged Affirmer hereby grants to each affected person a royalty-free, non transferable, non sublicensable, non exclusive, irrevocable and unconditional license to exercise Affirmer's Copyright and Related Rights in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "License"). The License shall be deemed effective as of the date CC0 was applied by Affirmer to the Work. Should any part of the License for any reason be judged legally invalid or ineffective under applicable law, such partial invalidity or ineffectiveness shall not invalidate the remainder of the License, and in such case Affirmer hereby affirms that he or she will not (i) exercise any of his or her remaining Copyright and Related Rights in the Work or (ii) assert any associated claims and causes of action with respect to the Work, in either case contrary to Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+    a. No trademark or patent rights held by Affirmer are waived, abandoned, surrendered, licensed or otherwise affected by this document.
+    b. Affirmer offers the Work as-is and makes no representations or warranties of any kind concerning the Work, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non infringement, or the absence of latent or other defects, accuracy, or the present or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
+    c. Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person's Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work.
+    d. Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.
+

--- a/resources/example/config/cc0.toml
+++ b/resources/example/config/cc0.toml
@@ -1,6 +1,3 @@
-customLicenses = []
-
-[CC0]
 path="./cc0.license"
 name="Creative Commons 0"
 identifier="cc0"

--- a/resources/example/config/cc0.toml
+++ b/resources/example/config/cc0.toml
@@ -1,0 +1,6 @@
+customLicenses = []
+
+[CC0]
+path="./cc0.license"
+name="Creative Commons 0"
+identifier="cc0"

--- a/resources/example/config/config.toml
+++ b/resources/example/config/config.toml
@@ -1,0 +1,1 @@
+customLicenses = []

--- a/resources/example/config/config.toml
+++ b/resources/example/config/config.toml
@@ -1,1 +1,1 @@
-customLicenses = []
+customLicenses = ["cc0"]

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -2,6 +2,7 @@ package args
 
 import (
 	"errors"
+	"license-generator/src/utils"
 	"strings"
 )
 
@@ -133,7 +134,7 @@ func (arg *Arguments) assignValueToArguments(argument *AvailableArgument, v stri
 	case "authors":
 		arg.Authors = parseAuthors(v)
 	case "config-path":
-		arg.ConfigPath = v
+		arg.ConfigPath = utils.RelativeToAbsolute(v, utils.ContextPath)
 	default:
 		return errors.New("unknown argument, use -h to see every arguments")
 	}

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -10,6 +10,7 @@ type Arguments struct {
 	LicenseType License
 	Year        string
 	Authors     []string
+	ConfigPath  string
 	Question    bool
 	Info        bool
 }
@@ -89,12 +90,17 @@ var (
 		Description: "Set the authors of the project, separate them with the coma (,)",
 		Argument:    "[string,]",
 	}
+	ConfigPath = AvailableArgument{
+		Parameter:   "config-path",
+		Description: "Set a path to the config for using custom licenses",
+		Argument:    "string",
+	}
 	HelpArg = InfoArgument{
 		Parameter:     "h",
 		textGenerator: helpText,
 		Description:   "Show the help",
 	}
-	argLists     = [4]AvailableArgument{AppNameArg, LicenseArg, YearArg, AuthorsArg}
+	argLists     = [5]AvailableArgument{AppNameArg, LicenseArg, YearArg, AuthorsArg, ConfigPath}
 	infoArgLists = [0]InfoArgument{}
 )
 
@@ -126,6 +132,8 @@ func (arg *Arguments) assignValueToArguments(argument *AvailableArgument, v stri
 		arg.Year = v
 	case "authors":
 		arg.Authors = parseAuthors(v)
+	case "config-path":
+		arg.ConfigPath = v
 	default:
 		return errors.New("unknown argument, use -h to see every arguments")
 	}

--- a/src/args/args.go
+++ b/src/args/args.go
@@ -14,21 +14,28 @@ type Arguments struct {
 	Info        bool
 }
 
-type License string
-
-const (
-	gpl     License = "GPLv3"
-	agpl    License = "AGPLv3"
-	lgpl    License = "LGPLv3"
-	mpl     License = "MPL"
-	mit     License = "MIT"
-	bsd     License = "BSD"
-	freebsd License = "FreeBSD"
-)
+type License struct {
+	Name string
+	File string
+}
 
 var (
-	licenseMap = make(map[string]License)
+	gpl        License = generateBasicLicense("GPLv3")
+	agpl       License = generateBasicLicense("AGPLv3")
+	lgpl       License = generateBasicLicense("LGPLv3")
+	mpl        License = generateBasicLicense("MPL")
+	mit        License = generateBasicLicense("MIT")
+	bsd        License = generateBasicLicense("BSD")
+	freebsd    License = generateBasicLicense("FreeBSD")
+	licenseMap         = make(map[string]License)
 )
+
+func generateBasicLicense(name string) License {
+	return License{
+		Name: name,
+		File: "~",
+	}
+}
 
 func GenerateLicenseMap() {
 	licenseMap["gpl"] = gpl
@@ -40,8 +47,13 @@ func GenerateLicenseMap() {
 	licenseMap["freebsd"] = freebsd
 }
 
-func GetLicense(name string) License {
-	return licenseMap[strings.ToLower(name)]
+func GetLicense(name string) (License, bool) {
+	lic, found := licenseMap[strings.ToLower(name)]
+	return lic, found
+}
+
+func AddLicense(license License, name string) {
+	licenseMap[name] = license
 }
 
 type AvailableArgument struct {
@@ -105,8 +117,8 @@ func (arg *Arguments) assignValueToArguments(argument *AvailableArgument, v stri
 	case "name":
 		arg.AppName = v
 	case "license":
-		license := GetLicense(v)
-		if license == "" {
+		license, found := GetLicense(v)
+		if !found {
 			return errors.New("invalid license type, available license type: " + mapLicenseToString(licenseMap))
 		}
 		arg.LicenseType = license
@@ -123,7 +135,7 @@ func (arg *Arguments) assignValueToArguments(argument *AvailableArgument, v stri
 func mapLicenseToString(m map[string]License) string {
 	str := ""
 	for _, license := range m {
-		str = str + ", " + string(license)
+		str = str + ", " + license.Name
 	}
 	return str
 }

--- a/src/args/manager.go
+++ b/src/args/manager.go
@@ -59,7 +59,7 @@ func (arg *Arguments) HandleArgs() {
 	}
 	m := make(map[string]string)
 	m["App Name"] = arg.AppName
-	m["License"] = string(arg.LicenseType)
+	m["License"] = arg.LicenseType.Name
 	m["Author(s)"] = utils.StringArrayToString(arg.Authors)
 	m["Year(s)"] = arg.Year
 	utils.GenerateSumeUp("Options", m, "-")
@@ -74,17 +74,17 @@ func (arg *Arguments) handleQuestion() {
 		println("The name is: " + name)
 		arg.AppName = name
 	}
-	if arg.LicenseType == "" {
+	if arg.LicenseType.Name == "" {
 		oldLicense := ""
 		print("License: ")
 		err := utils.Scan(&oldLicense)
 		utils.HandleError(err)
-		license := GetLicense(oldLicense)
-		if license == "" {
+		license, found := GetLicense(oldLicense)
+		if !found {
 			println("Unknown license type. Aborted.")
 			os.Exit(2)
 		}
-		println("The license is: " + license)
+		println("The license is: " + license.Name)
 		arg.LicenseType = license
 	}
 	if len(arg.Authors) == 0 {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1,0 +1,1 @@
+package config

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1,1 +1,75 @@
 package config
+
+import (
+	"errors"
+	"license-generator/src/args"
+	"license-generator/src/utils"
+	"os"
+	"regexp"
+)
+
+type MainConfig struct {
+	ListConfig []string `toml:"customLicenses"`
+}
+
+type LicenseConfig struct {
+	Path       string `toml:"path"`
+	Name       string `toml:"name"`
+	Identifier string `toml:"identifier"`
+}
+
+var (
+	regex = regexp.MustCompile(".*.toml")
+)
+
+func GetLicenseConfigs(path string) ([]LicenseConfig, error) {
+	files, err := os.ReadDir(path)
+	if err != nil {
+		utils.HandleError(err)
+	}
+
+	var config MainConfig
+	licenses := make(map[string]LicenseConfig)
+	for _, file := range files {
+		// remove directories and non toml files
+		if file.IsDir() || !regex.MatchString(file.Name()) {
+			continue
+		}
+		content := utils.FileContent(path, file)
+		if file.Name() == "config.toml" {
+			utils.DecodeToml(content, &config)
+			continue
+		}
+		var license LicenseConfig
+		utils.DecodeToml(content, &license)
+		licenses[license.Identifier] = license
+	}
+	final := make([]LicenseConfig, len(licenses))
+	if len(config.ListConfig) == 0 {
+		for _, s := range config.ListConfig {
+			v, found := licenses[s]
+			if !found {
+				return nil, errors.New("the license with the identifier " + s + " was not found")
+			}
+			final = append(final, v)
+		}
+	}
+	return final, nil
+}
+
+func (license *LicenseConfig) AddToMap(contextPath string) {
+	args.AddLicense(license.ToLicense(contextPath), license.Identifier)
+}
+
+func AddLicensesToMap(licenses []LicenseConfig, contextPath string) {
+	for _, license := range licenses {
+		license.AddToMap(contextPath)
+	}
+}
+
+func (license *LicenseConfig) ToLicense(contextPath string) args.License {
+	return args.License{
+		Name: license.Name,
+		File: utils.RelativeToAbsolute(license.Path, contextPath),
+	}
+}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -68,14 +68,11 @@ func GetLicenseConfigs(path string) ([]LicenseConfig, error) {
 }
 
 func (license *LicenseConfig) AddToMap(contextPath string) {
-	println("Path:", license.Path)
 	args.AddLicense(license.ToLicense(contextPath), license.Identifier)
 }
 
 func AddLicensesToMap(licenses []LicenseConfig, contextPath string) {
-	println("F:", licenses[0].Path)
 	for _, license := range licenses {
-		println("P:", license.Path)
 		license.AddToMap(contextPath)
 	}
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -38,31 +38,44 @@ func GetLicenseConfigs(path string) ([]LicenseConfig, error) {
 		content := utils.FileContent(path, file)
 		if file.Name() == "config.toml" {
 			utils.DecodeToml(content, &config)
+			println("Found the config.toml file")
 			continue
 		}
 		var license LicenseConfig
 		utils.DecodeToml(content, &license)
 		licenses[license.Identifier] = license
+		println("Imported", license.Name)
 	}
 	final := make([]LicenseConfig, len(licenses))
 	if len(config.ListConfig) == 0 {
-		for _, s := range config.ListConfig {
-			v, found := licenses[s]
-			if !found {
-				return nil, errors.New("the license with the identifier " + s + " was not found")
-			}
-			final = append(final, v)
+		i := 0
+		for _, licenseConfig := range licenses {
+			final[i] = licenseConfig
+			i++
 		}
+		return final, nil
+	}
+	i := 0
+	for _, s := range config.ListConfig {
+		v, found := licenses[s]
+		if !found {
+			return nil, errors.New("the license with the identifier " + s + " was not found")
+		}
+		final[i] = v
+		i++
 	}
 	return final, nil
 }
 
 func (license *LicenseConfig) AddToMap(contextPath string) {
+	println("Path:", license.Path)
 	args.AddLicense(license.ToLicense(contextPath), license.Identifier)
 }
 
 func AddLicensesToMap(licenses []LicenseConfig, contextPath string) {
+	println("F:", licenses[0].Path)
 	for _, license := range licenses {
+		println("P:", license.Path)
 		license.AddToMap(contextPath)
 	}
 }

--- a/src/utils/file.go
+++ b/src/utils/file.go
@@ -22,6 +22,7 @@ func DecodeToml(content []byte, t any) {
 //
 // contextPath: the contextual path, with a slash (/) at the end
 func RelativeToAbsolute(path string, contextPath string) string {
+	println(path, contextPath)
 	switch string(path[0]) {
 	case "/":
 		return path

--- a/src/utils/file.go
+++ b/src/utils/file.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"github.com/BurntSushi/toml"
+	"os"
+)
+
+func FileContent(path string, file os.DirEntry) []byte {
+	content, err := os.ReadFile(path + "/" + file.Name())
+	HandleError(err)
+	return content
+}
+
+func DecodeToml(content []byte, t any) {
+	_, err := toml.Decode(string(content), t)
+	HandleError(err)
+}
+
+// RelativeToAbsolute convert relative path into absolute path
+//
+// path: the path to convert
+//
+// contextPath: the contextual path, with a slash (/) at the end
+func RelativeToAbsolute(path string, contextPath string) string {
+	switch string(path[0]) {
+	case "/":
+		return path
+	case "~":
+		return path
+	case ".":
+		return contextPath + path[2:]
+	default:
+		return contextPath + path
+	}
+}

--- a/src/utils/file.go
+++ b/src/utils/file.go
@@ -22,7 +22,6 @@ func DecodeToml(content []byte, t any) {
 //
 // contextPath: the contextual path, with a slash (/) at the end
 func RelativeToAbsolute(path string, contextPath string) string {
-	println(path, contextPath)
 	switch string(path[0]) {
 	case "/":
 		return path

--- a/src/utils/file.go
+++ b/src/utils/file.go
@@ -5,6 +5,10 @@ import (
 	"os"
 )
 
+var (
+	ContextPath string
+)
+
 func FileContent(path string, file os.DirEntry) []byte {
 	content, err := os.ReadFile(path + "/" + file.Name())
 	HandleError(err)


### PR DESCRIPTION
## Summary

Add the support of custom license file through an argument passed and `TOML` file.

## Changelog

- Add the `--config-path` argument:
  - Require a path to a directory (example: `config/`)
  - Enable custom license
- Custom License
  - Add support of custom license

## Wiki

To use this new feature, follow this step-by-step.

### Create the configuration

Create a new folder.
Create a new file entitled `config.toml`. This file is not required but recommended.
Paste this content inside:
```toml
customLicenses = []
```
In the field `customLicenses`, you will put every enabled licenses. When you want to enable a license, just add the file name in the array. When you want to disable a license, just remove the file name from the array.

Create a new file entitled `your_license.toml`.
Paste this content inside:
```toml
path = "./cc0.license"
name = "Creative Commons 0"
identifier = "cc0"
```
In `path`, put a path (relative or absolute) to the license file. In `name`, put the name of the license. In `identifier`, put the identifier of the license (example: `cc0` for Creative Commons 0 or `gpl` for GPLv3), the identifier is used when we ask you wich license do you want to use.

Create a new file according to the path put in the `path` variable.
Put your license inside and replace the year(s) by `{{ .Year }}`, the author(s) by `{{ .Authors }}` and the project name by `{{ .AppName }}`.

### Use the configuration

Now, to use this configuration, you just need to add  `--config-path PATH_TO_YOUR_CONFIG` when using the command. Just, do not forget to replace the `PATH_TO_YOUR_CONFIG` by the path to your custom config (relative or absolute).
When the program will ask you wich license do you want to use, just use the identifier you put inside the file.