### PR TITLE
Change windows release format to zip

### DIFF
--- a/.gorelease.yaml
+++ b/.gorelease.yaml
@@ -22,6 +22,9 @@ archives:
       windows: Windows
       386: i386
       amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.gorelease.yaml
+++ b/.gorelease.yaml
@@ -16,12 +16,7 @@ builds:
     ldflags:
       - -H windowsgui
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
Opening tar.gz files on windows is annoying, as it is not possible without installing some software, so I changed the goreleaser configuration to make .zip files for windows releases.

Also, as the property 'archive.replacements' is [deprecated](https://goreleaser.com/deprecations/?h=replacemen#archivesreplacements), I replaced it by 'archive.name_template', as recommended in the docs.